### PR TITLE
Require email verification for transaction approval

### DIFF
--- a/persimmon/website/common.py
+++ b/persimmon/website/common.py
@@ -1,3 +1,6 @@
+from django.urls import reverse
+from django.core import mail
+
 from .models import User, DjangoUser, EmployeeLevel
 
 
@@ -23,3 +26,16 @@ def make_user(username,
         address=address,
         employee_level=employee_level,
         django_user=django_user)
+
+
+def do_approval(client, tid):
+    client.post(reverse('approve-transaction-page', args=(tid,)), {
+        'approved': True,
+    })
+    code = mail.outbox[-1].body.split()[-1]
+    client.post(reverse('approve-transaction-page', args=(tid,)), {
+        'approved': True,
+        'email_verification': code,
+    })
+
+

--- a/persimmon/website/common.py
+++ b/persimmon/website/common.py
@@ -37,5 +37,3 @@ def do_approval(client, tid):
         'approved': True,
         'email_verification': code,
     })
-
-

--- a/persimmon/website/common.py
+++ b/persimmon/website/common.py
@@ -32,7 +32,7 @@ def do_approval(client, tid):
     client.post(reverse('approve-transaction-page', args=(tid,)), {
         'approved': True,
     })
-    code = mail.outbox[-1].body.split()[-1]
+    code = mail.outbox[-1].body.split()[-1]  # pylint: disable=no-member
     client.post(reverse('approve-transaction-page', args=(tid,)), {
         'approved': True,
         'email_verification': code,

--- a/persimmon/website/models.py
+++ b/persimmon/website/models.py
@@ -148,7 +148,12 @@ class Transaction(models.Model):
         constraints = [models.constraints.CheckConstraint(check=models.Q(transaction__gt=0), name='positive_value')]
 
     def __str__(self):
-        return f'<Transaction "{self.description}" ${self.transaction}>'
+        pieces = [f'Transaction of ${self.transaction}']
+        if self.account_subtract:
+            pieces.append(f'from {self.account_subtract.owner.name}')
+        if self.account_add:
+            pieces.append(f'to {self.account_add.owner.name}')
+        return ' '.join(pieces)
 
     @property
     def is_transfer(self):

--- a/persimmon/website/templates/pages/bank_account.html
+++ b/persimmon/website/templates/pages/bank_account.html
@@ -20,13 +20,9 @@
         <td>${{ entry.transaction }}</td>
         {% if entry.balance is None %}
             {% if entry.can_approve %}
-                <td><form action="{% url 'approve-transaction' %}" method="POST">
-                    {% csrf_token %}
-                    <input type="hidden" name="transaction_id" value="{{ entry.id }}">
-                    <input type="hidden" name="back" value="{{ request.path }}">
-                    <button name="approved" value="true" type="submit">Approve</button><br>
-                    <button name="approved" value="false" type="submit">Decline</button>
-                </form></td>
+                <td><em><a href="{% url 'approve-transaction-page' entry.id %}?back={{ request.path }}">
+                    Approve or Decline
+                </a></em></td>
             {% else %}
                 <td><em>Pending approval</em></td>
             {% endif %}

--- a/persimmon/website/templates/pages/employee_page.html
+++ b/persimmon/website/templates/pages/employee_page.html
@@ -17,13 +17,7 @@
                     (<a href="{% url 'user' transaction.account_add.account_number %}">{{ transaction.account_add.owner.name }}</a>
                     volume {{ transaction.account_add.owner.transaction_volume }})
                 {% endif %}
-                <form action="{% url 'approve-transaction' %}" method="POST">
-                    {% csrf_token %}
-                    <input type="hidden" name="transaction_id" value="{{ transaction.id }}">
-                    <input type="hidden" name="back" value="{{ request.path }}">
-                    <button name="approved" value="true" type="submit">Approve</button>
-                    <button name="approved" value="false" type="submit">Decline</button>
-                </form>
+                <a href="{% url 'approve-transaction-page' transaction.id %}?back={{ request.path }}">Approve or Decline</a>
             </li>
         {% endfor %}
     </ul>

--- a/persimmon/website/templates/pages/mobile_atm_fail.html
+++ b/persimmon/website/templates/pages/mobile_atm_fail.html
@@ -1,5 +1,0 @@
-{% extends 'main.html' %}
-{% block title %}Atm Fail{% endblock %}
-{% block body %}
-An Error has occurred. Transaction cancelled.
-{% endblock %}

--- a/persimmon/website/templates/pages/mobile_atm_success.html
+++ b/persimmon/website/templates/pages/mobile_atm_success.html
@@ -1,5 +1,0 @@
-{% extends 'main.html' %}
-{% block title %}ATM succ{% endblock %}
-{% block body %}
-<p>Transaction Succesfull</p>
-{% endblock %}

--- a/persimmon/website/templates/pages/transaction_approval.html
+++ b/persimmon/website/templates/pages/transaction_approval.html
@@ -1,0 +1,11 @@
+{% extends 'main.html' %}
+{% block title %}Approve Transaction{% endblock %}
+{% block body %}
+    <h2>Approve this transaction?</h2>
+    <p>{{ transaction }}</p>
+    <form method="POST">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <p><input type="submit" value="Submit"></p>
+    </form>
+{% endblock %}

--- a/persimmon/website/templates/pages/transaction_approval_success.html
+++ b/persimmon/website/templates/pages/transaction_approval_success.html
@@ -1,6 +1,6 @@
 {% extends 'main.html' %}
 {% block title %}Success{% endblock %}
 {% block body %}
-    <p>Transaction approved successfully.</p>
+    <p>Transaction {% if approved %}approved{% else %}declined{% endif %} successfully.</p>
     <p><a href="{{ link }}">Go back</a></p>
 {% endblock %}

--- a/persimmon/website/templates/pages/transfer_success.html
+++ b/persimmon/website/templates/pages/transfer_success.html
@@ -1,5 +1,0 @@
-{% extends 'main.html' %}
-{% block title %}Transfer Submitted{% endblock %}
-{% block body %}
-    Your transfer has been submitted.
-{% endblock %}

--- a/persimmon/website/transaction_approval.py
+++ b/persimmon/website/transaction_approval.py
@@ -1,3 +1,5 @@
+from django.db import transaction
+
 from .models import Transaction, ApprovalStatus, EmployeeLevel, User
 
 CRITICAL_THRESHOLD = 1000
@@ -41,6 +43,7 @@ def required_approvals(stmt: Transaction):
     return employee_approval, user_approval
 
 
+@transaction.atomic
 def check_approvals(stmt: Transaction, user: User):
     """
     Check if a user can approve a transaction. As a side effect, if the transaction can be automatically approved,

--- a/persimmon/website/urls.py
+++ b/persimmon/website/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
     path('account/approve', apis.approve_bank_account, name='approve-account'),
 
     path('transaction/<int:tid>/check.png', apis.check_image, name='check'),
-    path('transaction/approve', apis.approve_transaction, name='approve-transaction'),
+    path('transaction/<int:tid>/approve', apis.approve_transaction_page, name='approve-transaction-page'),
 
     path('appointment', html_views.schedule_appointment_page, name='appointment'),
     path('employee-view', html_views.employee_page, name='employee'),

--- a/persimmon/website/views/apis.py
+++ b/persimmon/website/views/apis.py
@@ -10,7 +10,7 @@ from django.core.validators import RegexValidator
 from django.contrib.auth import authenticate, login as django_login
 from django.db import transaction
 from django.db.models import Q
-from django.http import Http404, HttpResponseBadRequest, HttpResponseNotFound, HttpResponseForbidden, HttpResponse
+from django.http import Http404, HttpResponseBadRequest, HttpResponse
 from django import forms
 from django.template.response import TemplateResponse
 from django.views.decorators.http import require_POST
@@ -95,6 +95,7 @@ class ApproveTransactionForm(forms.Form):
     approved = forms.BooleanField(required=False)
 
 
+@transaction.atomic
 def approve_transaction_page(request, tid):
     user = current_user(request)
     form = ApproveTransactionForm(request.POST or None)

--- a/persimmon/website/views/apis.py
+++ b/persimmon/website/views/apis.py
@@ -92,37 +92,55 @@ def approve_bank_account(request):
 
 
 class ApproveTransactionForm(forms.Form):
-    transaction_id = forms.IntegerField()
     approved = forms.BooleanField(required=False)
-    back = forms.CharField()
 
 
-@transaction.atomic
-@require_POST
-def approve_transaction(request):
+def approve_transaction_page(request, tid):
     user = current_user(request)
-    form = ApproveTransactionForm(request.POST)
-    if not form.is_valid():
-        return HttpResponseBadRequest("Bad parameters")
-
+    form = ApproveTransactionForm(request.POST or None)
     try:
-        pendingtransaction = Transaction.objects.get(
-            id=form.cleaned_data['transaction_id'],
-            approval_status=ApprovalStatus.PENDING)
-    except Transaction.DoesNotExist:
-        return HttpResponseNotFound("No such transaction pending approval")
+        trans = Transaction.objects.get(id=tid, approval_status=ApprovalStatus.PENDING)
+        if not check_approvals(trans, user):
+            raise Transaction.DoesNotExist
+    except Transaction.DoesNotExist as exc:
+        raise Http404("No such transaction") from exc
 
-    if not check_approvals(pendingtransaction, user):
-        return HttpResponseForbidden("You cannot approve this transaction")
+    if form.is_valid():
+        verification_code = make_verification_code(
+            'approve_transaction',
+            str(form.cleaned_data['approved']),
+            user.username,
+            str(tid))
+        form.fields['email_verification'] = forms.CharField()
+        form.full_clean()
+        if not form.is_valid():
+            mail.send_mail(
+                "Persimmon verification code",
+                f"Here is the code to verify your transaction approval: {verification_code}",
+                settings.EMAIL_SENDER,
+                [user.email]
+            )
+            form.errors.clear()
+            form.add_error(
+                'email_verification',
+                'Please check your email and enter the code we sent you here')
+        elif form.cleaned_data['email_verification'] != verification_code:
+            form.add_error('email_verification', 'Invalid code')
+        else:
+            if form.cleaned_data['approved']:
+                trans.add_approval(user)
+                check_approvals(trans, user)
+            else:
+                trans.decline()
 
-    if form.cleaned_data['approved']:
-        pendingtransaction.add_approval(user)
-        check_approvals(pendingtransaction, user)
-    else:
-        pendingtransaction.decline()
+            return TemplateResponse(request, 'pages/transaction_approval_success.html', {
+                'approved': form.cleaned_data['approved'],
+                'link': request.GET.get("back", None)
+            })
 
-    return TemplateResponse(request, 'pages/transaction_approval_success.html', {
-        'link': form.cleaned_data['back'],
+    return TemplateResponse(request, 'pages/transaction_approval.html', {
+        'transaction': trans,
+        'form': form,
     })
 
 

--- a/persimmon/website/views/html_views.py
+++ b/persimmon/website/views/html_views.py
@@ -7,6 +7,7 @@ from django import forms, urls
 from django.template.response import TemplateResponse
 from django.contrib.auth import logout as django_logout, login as django_login, forms as auth_forms
 from django.conf import settings
+from django.shortcuts import redirect
 from sms import send_sms
 
 from ..models import BankAccount, ApprovalStatus, DjangoUser, EmployeeLevel, User, Transaction, Appointment
@@ -266,8 +267,7 @@ def mobile_atm_page(request):
             approval_status=ApprovalStatus.PENDING,
             check_recipient=form.cleaned_data['check_recipient'] or None)
 
-        trans.add_approval(user)
-        return TemplateResponse(request, 'pages/mobile_atm_success.html', {})
+        return redirect(urls.reverse('approve-transaction-page', args=(trans.id,)) + "?back=" + request.path)
 
     return TemplateResponse(request, 'pages/mobile_atm.html', {
         'form': form,
@@ -306,10 +306,7 @@ def transfer_page(request):
             approval_status=ApprovalStatus.PENDING,
         )
 
-        trans.add_approval(user)
-        check_approvals(trans, user)
-
-        return TemplateResponse(request, 'pages/transfer_success.html', {})
+        return redirect(urls.reverse('approve-transaction-page', args=(trans.id,)) + "?back=" + request.path)
 
     return TemplateResponse(request, 'pages/transfer.html', {
         'form': form,


### PR DESCRIPTION
Creates a new page requiring 2fa to execute the transaction.add_approval() action. This changes the workflow for credit/debit, transfer, statement-approvals, and employee-approvals.